### PR TITLE
Stop event propagation if bubbles=false

### DIFF
--- a/addon/components/md-button.js
+++ b/addon/components/md-button.js
@@ -33,6 +33,9 @@ var MdButtonComponent = Ember.Component.extend(LayoutRules, RipplesMixin, {
 
     click() {
         this.sendAction('action', this.get('param'));
+        if ( this.get('bubbles') === false ) {
+          e.stopPropagation();
+        }
     }
 
 });


### PR DESCRIPTION
Stop the click event from bubbling if `bubbles=false` is passed into the md-button helper.